### PR TITLE
Renaming 'flux-redux-reducer' to 'focus-redux-reducer' import

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Also a special `default` method can be defined and will be called when the `acti
 
 **MyReducer.js**
 ```javascript
-import Reducer from 'flux-redux-reducer';
+import Reducer from 'focus-redux-reducer';
 import { createStore } from 'react-redux';
 
 class MyReducer extends Reducer {


### PR DESCRIPTION
From the example I am getting the below error:
```Failed to compile
Module not found: Can't resolve 'flux-redux-reducer'```

The solution is simply renaming the `flux-redux-reducer` to `focus-redux-reducer` (the actual name of the npm repository)